### PR TITLE
Add ability to sendPrivate

### DIFF
--- a/src/help.coffee
+++ b/src/help.coffee
@@ -70,8 +70,11 @@ module.exports = (robot) ->
       cmd.replace new RegExp("^#{robot.name}"), prefix
 
     emit = cmds.join "\n"
-
-    msg.send emit
+    
+    if msg.sendPrivate
+      msg.sendPrivate emit
+    else
+      msg.send emit
 
   robot.router.get "/#{robot.name}/help", (req, res) ->
     cmds = robot.helpCommands().map (cmd) ->


### PR DESCRIPTION
The IRC adapter added `sendPrivate` for redirecting long output to privmsg. Making this the default on IRC would be amazing. 

IDK if people want to add something to configure it to send to channel, but in most cases, I don't think people want all the output going to the whole IRC channel by default.
