### PR TITLE
Add cross-package 'help:lookup' listener

### DIFF
--- a/src/help.coffee
+++ b/src/help.coffee
@@ -54,6 +54,20 @@ helpContents = (name, commands) ->
 
 module.exports = (robot) ->
   robot.respond /help\s*(.*)?$/i, (msg) ->
+    robot.emit 'help:lookup', msg
+
+  robot.router.get "/#{robot.name}/help", (req, res) ->
+    cmds = renamedHelpCommands(robot).map (cmd) ->
+      cmd.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+
+    emit = "<p>#{cmds.join '</p><p>'}</p>"
+
+    emit = emit.replace new RegExp("#{robot.name}", "ig"), "<b>#{robot.name}</b>"
+
+    res.setHeader 'content-type', 'text/html'
+    res.end helpContents robot.name, emit
+
+  robot.on 'help:lookup', (msg) ->
     cmds = renamedHelpCommands(robot)
     filter = msg.match[1]
 
@@ -67,17 +81,6 @@ module.exports = (robot) ->
     emit = cmds.join "\n"
 
     msg.send emit
-
-  robot.router.get "/#{robot.name}/help", (req, res) ->
-    cmds = renamedHelpCommands(robot).map (cmd) ->
-      cmd.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
-
-    emit = "<p>#{cmds.join '</p><p>'}</p>"
-
-    emit = emit.replace new RegExp("#{robot.name}", "ig"), "<b>#{robot.name}</b>"
-
-    res.setHeader 'content-type', 'text/html'
-    res.end helpContents robot.name, emit
 
 renamedHelpCommands = (robot) ->
   robot_name = robot.alias or robot.name


### PR DESCRIPTION
Problem: You create a script package that has a namespaced command, such as:

```
user>> hubot widget me foobar
hubot>> Your foobar widget is coming right up!
```

Inevitably, it gets more complex than that, so you are tempted to add something like this:

```
robot.respond /widget help/, (msg) ->
  msg.send "#{robot.name} widget me <something> - get a lovely widget"
  [...]
```

This is lame, because you already have the command list in the header. And for some reason, folks can never remember to put the `help` before the namespaced command.

This PR offers developers the ability to add a boilerplate:

```
robot.respond /widget help/, (msg) ->
  msg.match[1] = 'widget'
  robot.emit 'help:lookup', msg
```

and it will route back through the commonly-installed `hubot-help` package and reflect back its help text.

---

This is a proposed idea -- there may be a better way to do it using Hubot internals (and without changing this package), but I could not find one.
