### PR TITLE
Add an option.id to the help command

### DIFF
--- a/src/help.coffee
+++ b/src/help.coffee
@@ -53,7 +53,7 @@ helpContents = (name, commands) ->
   """
 
 module.exports = (robot) ->
-  robot.respond /help(?:\s+(.*))?$/i, (msg) ->
+  robot.respond /help(?:\s+(.*))?$/i, id:'hubot-help.help', (msg) ->
     cmds = renamedHelpCommands(robot)
     filter = msg.match[1]
 


### PR DESCRIPTION
I've a hubot instance that deploys and scale applications. Also provides information on the instances and dns records.

I've a list of users that are able to use all the commands. And a tiny list of commands that I want to allow everyone to use (dns records, instance records and help)

But since the help command has no option.id I can't check if the requested command is in the list of whitelisted commands
