### PR TITLE
Replace "hubot" with name/alias in the beginning of the string only

### DIFF
--- a/src/help.coffee
+++ b/src/help.coffee
@@ -80,7 +80,7 @@ module.exports = (robot) ->
     res.end helpContents robot.name, emit
 
 renamedHelpCommands = (robot) ->
-  robot_name = robot.alias or "#{robot.name} "
+  robot_name = robot.alias or robot.name
   help_commands = robot.helpCommands().map (command) ->
-    command.replace /^hubot /i, robot_name
+    command.replace /^hubot/i, robot_name
   help_commands.sort()

--- a/src/help.coffee
+++ b/src/help.coffee
@@ -80,7 +80,7 @@ module.exports = (robot) ->
     res.end helpContents robot.name, emit
 
 renamedHelpCommands = (robot) ->
-  robot_name = robot.alias or robot.name
+  robot_name = robot.alias or "#{robot.name} "
   help_commands = robot.helpCommands().map (command) ->
-    command.replace /hubot/ig, robot_name
+    command.replace /^hubot /i, robot_name
   help_commands.sort()


### PR DESCRIPTION
In the current version every occurrence of "hubot" in the help entry is replaced. This becomes a problem when you actually have "hubot" in your command or description, i.e. `restart hubot` command would result in `restart !` in help. I fixed the script to only replace "hubot" in the beginning of the string.
