### PR TITLE
Reply to help in private

### DIFF
--- a/src/help.coffee
+++ b/src/help.coffee
@@ -66,7 +66,10 @@ module.exports = (robot) ->
 
     emit = cmds.join "\n"
 
-    msg.reply emit
+    if msg.message?.user?.name?
+      robot.send {room: msg.message?.user?.name}, emit
+    else
+      msg.reply emit
 
   robot.router.get "/#{robot.name}/help", (req, res) ->
     cmds = renamedHelpCommands(robot).map (cmd) ->

--- a/src/help.coffee
+++ b/src/help.coffee
@@ -67,6 +67,7 @@ module.exports = (robot) ->
     emit = cmds.join "\n"
 
     if msg.message?.user?.name?
+      msg.reply 'replied to you in private!'
       robot.send {room: msg.message?.user?.name}, emit
     else
       msg.reply emit

--- a/src/help.coffee
+++ b/src/help.coffee
@@ -66,7 +66,7 @@ module.exports = (robot) ->
 
     emit = cmds.join "\n"
 
-    msg.send emit
+    msg.reply emit
 
   robot.router.get "/#{robot.name}/help", (req, res) ->
     cmds = renamedHelpCommands(robot).map (cmd) ->

--- a/src/help.coffee
+++ b/src/help.coffee
@@ -8,6 +8,9 @@
 # URLS:
 #   /hubot/help
 #
+# Configuration:
+#   HUBOT_HELP_REPLY_IN_PRIVATE
+#
 # Notes:
 #   These commands are grabbed from comment blocks at the top of each file.
 
@@ -53,6 +56,8 @@ helpContents = (name, commands) ->
   """
 
 module.exports = (robot) ->
+  replyInPrivate = process.env.HUBOT_HELP_REPLY_IN_PRIVATE
+
   robot.respond /help(?:\s+(.*))?$/i, (msg) ->
     cmds = renamedHelpCommands(robot)
     filter = msg.match[1]
@@ -66,7 +71,7 @@ module.exports = (robot) ->
 
     emit = cmds.join "\n"
 
-    if msg.message?.user?.name?
+    if replyInPrivate and msg.message?.user?.name?
       msg.reply 'replied to you in private!'
       robot.send {room: msg.message?.user?.name}, emit
     else


### PR DESCRIPTION
One of the annoyities in chatops is scrolling over 4123123123 lines of @hubot help results.

This little PR replies to whomever needed help in private, not cluttering a room / channel.

To Opt in to the feature, add the HUBOT_HELP_REPLY_IN_PRIVATE environment variable
