### PR TITLE
Add grunt as development dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chai": "*",
     "sinon-chai": "*",
     "sinon": "*",
-    "grunt": "~0.4.0",
+    "grunt": "~1.0.1",
     "grunt-mocha-test": "~0.7.0",
     "grunt-release": "~0.6.0",
     "matchdep": "~0.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "chai": "*",
     "sinon-chai": "*",
     "sinon": "*",
+    "grunt": "~0.4.0",
     "grunt-mocha-test": "~0.7.0",
     "grunt-release": "~0.6.0",
     "matchdep": "~0.1.2",


### PR DESCRIPTION
Fixes:

    $ grunt test
    grunt-cli: The grunt command line interface. (v0.1.13)

    Fatal error: Unable to find local grunt.

    If you're seeing this message, either a Gruntfile wasn't found or grunt
    hasn't been installed locally to your project. For more information about
    installing and configuring grunt, please see the Getting Started guide:

    http://gruntjs.com/getting-started