### PR TITLE
Replace hubot no matter where it is in command

### DIFF
--- a/src/help.coffee
+++ b/src/help.coffee
@@ -91,5 +91,5 @@ module.exports = (robot) ->
 renamedHelpCommands = (robot) ->
   robot_name = robot.alias or robot.name
   help_commands = robot.helpCommands().map (command) ->
-    command.replace /^hubot/i, robot_name
+    command.replace /hubot/i, robot_name
   help_commands.sort()


### PR DESCRIPTION
This will allow the hubot name to be removed no matter where it is in the command, in case your command starts with something besides the bot name. 