### PR TITLE
Fix broken private messages, and increase code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,14 @@
     "grunt-release": "^0.14.0",
     "hubot": "^3.0.0",
     "hubot-mock-adapter-v3": "^1.0.0",
+    "hubot-test-helper": "^1.8.1",
     "matchdep": "^0.1.2",
     "mocha": "^3.0.2",
     "nyc": "^11.0.3",
+    "semantic-release": "^6.3.6",
     "sinon": "^1.4.2",
     "sinon-chai": "^2.8.0",
-    "standard": "^10.0.2",
-    "semantic-release": "^6.3.6"
+    "standard": "^10.0.2"
   },
   "main": "index.coffee",
   "scripts": {

--- a/src/help.js
+++ b/src/help.js
@@ -73,7 +73,7 @@ module.exports = (robot) => {
     const emit = cmds.join('\n')
 
     if (process.env.HUBOT_HELP_REPLY_IN_PRIVATE && msg.message && msg.message.user && msg.message.user.name && msg.message.user.name !== msg.message.room) {
-      msg.reply('replied to you in private!')
+      msg.reply('I just replied to you in private.')
       return msg.sendPrivate(emit)
     } else {
       return msg.send(emit)

--- a/src/help.js
+++ b/src/help.js
@@ -58,8 +58,6 @@ const helpContents = (name, commands) => `\
 `
 
 module.exports = (robot) => {
-  const replyInPrivate = process.env.HUBOT_HELP_REPLY_IN_PRIVATE
-
   robot.respond(/help(?:\s+(.*))?$/i, (msg) => {
     let cmds = getHelpCommands(robot)
     const filter = msg.match[1]
@@ -74,9 +72,9 @@ module.exports = (robot) => {
 
     const emit = cmds.join('\n')
 
-    if (replyInPrivate && msg.message && msg.message.user && msg.message.user.name && msg.message.user.name !== msg.message.room) {
+    if (process.env.HUBOT_HELP_REPLY_IN_PRIVATE && msg.message && msg.message.user && msg.message.user.name && msg.message.user.name !== msg.message.room) {
       msg.reply('replied to you in private!')
-      return robot.send({ room: msg.message.user.name }, emit)
+      return msg.sendPrivate(emit)
     } else {
       return msg.send(emit)
     }

--- a/test/help_message_visibility_test.js
+++ b/test/help_message_visibility_test.js
@@ -13,6 +13,7 @@ const helper = new Helper('../src/help.js')
 
 describe('help', () => describe('message visibility', () => {
   beforeEach(function () {
+    this.timeout(5000)
     this.room = helper.createRoom()
   })
 

--- a/test/help_message_visibility_test.js
+++ b/test/help_message_visibility_test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+/* global describe, beforeEach, afterEach, it, context */
+
+const chai = require('chai')
+const expect = chai.expect
+
+chai.use(require('sinon-chai'))
+
+const Helper = require('hubot-test-helper')
+
+const helper = new Helper('../src/help.js')
+
+describe('help', () => describe('message visibility', () => {
+  beforeEach(function () {
+    this.room = helper.createRoom()
+  })
+
+  afterEach(function () {
+    this.room.destroy()
+  })
+
+  context('when HUBOT_HELP_REPLY_IN_PRIVATE is set', () => it('replies in a private message', function (done) {
+    process.env.HUBOT_HELP_REPLY_IN_PRIVATE = true
+    this.room.user.say('john', '@hubot help help').then(() => {
+      expect(this.room.messages).to.eql([
+        ['john', '@hubot help help'],
+        ['hubot', '@john replied to you in private!']
+      ])
+      expect(this.room.privateMessages).to.eql({
+        john: [
+            ['hubot', 'hubot help - Displays all of the help commands that this bot knows about.\nhubot help <query> - Displays all help commands that match <query>.']
+        ]
+      })
+    })
+  }))
+
+  context('when HUBOT_HELP_REPLY_IN_PRIVATE is unset', () => it('replies in the same room', function (done) {
+    this.room.user.say('john', '@hubot help help').then(() => {
+      expect(this.room.messages).to.eql([
+        ['john', '@hubot help help'],
+        ['hubot', '@john replied to you in private!']
+      ])
+      expect(this.room.privateMessages).to.eql({
+        john: [
+            ['hubot', 'hubot help - Displays all of the help commands that this bot knows about.\nhubot help <query> - Displays all help commands that match <query>.']
+        ]
+      })
+    })
+  }))
+}))

--- a/test/help_message_visibility_test.js
+++ b/test/help_message_visibility_test.js
@@ -45,7 +45,7 @@ describe('help', () => describe('message visibility', () => {
     this.room.user.say('john', '@hubot help help').then(() => {
       expect(this.room.messages).to.eql([
         ['john', '@hubot help help'],
-        ['hubot', '@john replied to you in private!']
+        ['hubot', '@john I just replied to you in private.']
       ])
       expect(this.room.privateMessages).to.eql({
         john: [

--- a/test/help_message_visibility_test.js
+++ b/test/help_message_visibility_test.js
@@ -20,25 +20,31 @@ describe('help', () => describe('message visibility', () => {
     this.room.destroy()
   })
 
-  context('when HUBOT_HELP_REPLY_IN_PRIVATE is set', () => it('replies in a private message', function (done) {
-    process.env.HUBOT_HELP_REPLY_IN_PRIVATE = true
-    this.room.user.say('john', '@hubot help help').then(() => {
-      expect(this.room.messages).to.eql([
-        ['john', '@hubot help help'],
-        ['hubot', '@john replied to you in private!']
-      ])
-      expect(this.room.privateMessages).to.eql({
-        john: [
-            ['hubot', 'hubot help - Displays all of the help commands that this bot knows about.\nhubot help <query> - Displays all help commands that match <query>.']
-        ]
-      })
-    })
-  }))
-
   context('when HUBOT_HELP_REPLY_IN_PRIVATE is unset', () => it('replies in the same room', function (done) {
     this.room.user.say('john', '@hubot help help').then(() => {
       expect(this.room.messages).to.eql([
         ['john', '@hubot help help'],
+        ['hubot', 'hubot help - Displays all of the help commands that this bot knows about.\nhubot help <query> - Displays all help commands that match <query>.']
+      ])
+    }).then(done, done)
+  }))
+}))
+
+describe('help', () => describe('message visibility', () => {
+  beforeEach(function () {
+    process.env.HUBOT_HELP_REPLY_IN_PRIVATE = true
+    this.room = helper.createRoom()
+  })
+
+  afterEach(function () {
+    delete process.env.HUBOT_HELP_REPLY_IN_PRIVATE
+    this.room.destroy()
+  })
+
+  context('when HUBOT_HELP_REPLY_IN_PRIVATE is set', () => it('replies in a private message', function (done) {
+    this.room.user.say('john', '@hubot help help').then(() => {
+      expect(this.room.messages).to.eql([
+        ['john', '@hubot help help'],
         ['hubot', '@john replied to you in private!']
       ])
       expect(this.room.privateMessages).to.eql({
@@ -46,6 +52,6 @@ describe('help', () => describe('message visibility', () => {
             ['hubot', 'hubot help - Displays all of the help commands that this bot knows about.\nhubot help <query> - Displays all help commands that match <query>.']
         ]
       })
-    })
+    }).then(done, done)
   }))
 }))


### PR DESCRIPTION
This fixes a bug with bot replies being sent as a private message rather than a public one, and it adds test coverage to prove it. I couldn't figure out how to test private messages using [hubot-mock-adapter-v3](https://www.npmjs.com/package/hubot-mock-adapter-v3), so I used [hubot-test-helper](https://www.npmjs.com/package/hubot-test-helper) instead, but I'd love to see how to test this without introducing a new dependency, if that's possible :)