### PR TITLE
Expand reply-in-private for user.id, custom message

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ You can set various environment variables to tune up the behavior of thios help 
 - `HUBOT_HELP_REPLY_IN_PRIVATE` (set to any value) will force calls to `hubot help` to be answered in private
 - `HUBOT_HELP_DISABLE_HTTP` (set to any value) will disable the web interface for help
 - `HUBOT_HELP_HIDDEN_COMMANDS` comma-separated list of commands that will not be displayed in help
+- `HUBOT_HELP_PRIVATE_MSG` Message to inform user that hubot replied in private
+- `HUBOT_HELP_USE_ID` Reply to user id instead of user name
 
 Development
 -----------------

--- a/src/help.js
+++ b/src/help.js
@@ -15,7 +15,7 @@
 //   HUBOT_HELP_DISABLE_HTTP - if set, no web entry point will be declared
 //   HUBOT_HELP_HIDDEN_COMMANDS - comma-separated list of commands that will not be displayed in help
 //   HUBOT_HELP_REPLY_IN_PRIVATE - Reply in private to `help`
-//   HUBOT_HELP_PRIVATE_MSG      - Message to inform user that hubot replied in public
+//   HUBOT_HELP_PRIVATE_MSG      - Message to inform user that hubot replied in private
 //   HUBOT_HELP_USE_ID           - Reply to user id instead of user name
 //
 // Notes:

--- a/src/help.js
+++ b/src/help.js
@@ -92,7 +92,7 @@ module.exports = (robot) => {
     const emit = cmds.join('\n')
 
     if (replyInPrivateCheck(replyInPrivate, msg)) {
-      if(msgUserNameCheck(msg) {
+      if(msgUserNameCheck(msg)) {
         msg.reply(privateNotifMessage)
       }
       if (useId && msgUserIdCheck(msg)) {

--- a/src/help.js
+++ b/src/help.js
@@ -66,16 +66,16 @@ const msgUserNameCheck = (msg) => {
 
 const msgUserIdCheck = (msg) => {
   return msg.message.id && msg.message.user.id && msg.message.user.id !== msg.message.room
- }
+}
 
 const replyInPrivateCheck = (replyInPrivate, msg) => {
   return replyInPrivate && msg.message && (msgUserNameCheck(msg) || msgUserIdCheck(msg))
 }
 
 module.exports = (robot) => {
-  const replyInPrivate      = process.env.HUBOT_HELP_REPLY_IN_PRIVATE
+  const replyInPrivate = process.env.HUBOT_HELP_REPLY_IN_PRIVATE
   const privateNotifMessage = process.env.HUBOT_HELP_PRIVATE_MSG || 'replied to you in private!'
-  const useId               = process.env.HUBOT_HELP_USE_ID
+  const useId = process.env.HUBOT_HELP_USE_ID
 
   robot.respond(/help(?:\s+(.*))?$/i, (msg) => {
     let cmds = getHelpCommands(robot)
@@ -92,7 +92,7 @@ module.exports = (robot) => {
     const emit = cmds.join('\n')
 
     if (replyInPrivateCheck(replyInPrivate, msg)) {
-      if(msgUserNameCheck(msg)) {
+      if (msgUserNameCheck(msg)) {
         msg.reply(privateNotifMessage)
       }
       if (useId && msgUserIdCheck(msg)) {


### PR DESCRIPTION
Allowing the reply-in-private to leverage msg.message.user.id in case duplicate user names are allowed.

Allow the use of a custom notification message telling the user that they were replied to in private.

(Update of #20, which was coffeescript, will update Readme in another commit)