### PR TITLE
Allow '@bot help' in a direct message, the same as in a channel

### DIFF
--- a/src/help.js
+++ b/src/help.js
@@ -58,9 +58,10 @@ const helpContents = (name, commands) => `\
 `
 
 module.exports = (robot) => {
-  robot.respond(/help(?:\s+(.*))?$/i, (msg) => {
+  const helpRE = new RegExp('(@' + robot.name + '\\s)?help(?:\\s+(.*))?$', 'i')
+  robot.respond(helpRE, (msg) => {
     let cmds = getHelpCommands(robot)
-    const filter = msg.match[1]
+    const filter = msg.match[2]
 
     if (filter) {
       cmds = cmds.filter(cmd => cmd.match(new RegExp(filter, 'i')))


### PR DESCRIPTION
hubot-help currently responds to `@bot help` in a channel and only `help` in direct messages.

In a direct message, `@bot help` does not respond with anything, so this adds that as an option.

Some of the slackbots I interact with don't use hubot and require the robot name prefix even in direct messages, so it confuses me when one using hubot does not respond at all in a DM.

I could not find a way to add tests for direct messages<br><br>

Also, can this repo be assigned a License? I see MIT used for many other hubotio projects, but nothing on this one