### PR TITLE
Fix `package.json` > `main` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sinon-chai": "^2.8.0",
     "standard": "^10.0.2"
   },
-  "main": "index.coffee",
+  "main": "index.js",
   "scripts": {
     "pretest": "standard",
     "test": "nyc --reporter=html --reporter=text mocha",


### PR DESCRIPTION
In the de-coffeescripting, this was missed. Complains as a warning when bot boots up.

```
(node:6) [DEP0128] DeprecationWarning: Invalid 'main' field in '/opt/hubot/node_modules/hubot-help/package.json' of 'index.coffee'. Please either fix that or report it to the module author
```