### PR TITLE
Update main to prevent error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sinon-chai": "^2.8.0",
     "standard": "^10.0.2"
   },
-  "main": "index.coffee",
+  "main": "index.js",
   "scripts": {
     "pretest": "standard",
     "test": "nyc --reporter=html --reporter=text mocha",


### PR DESCRIPTION
Got the following error:

```node:5832) [DEP0128] DeprecationWarning: Invalid 'main' field in 'C:\projects\blaze-slack-chatops-service\node_modules\hubot-help\package.json' of 'index.coffee'. Please either fix that or report it to the module author (Use `node --trace-deprecation ...` to show where the warning was created)```

Fixes it.