### PR TITLE
fix(help): HUBOT_HELP_HIDDEN_COMMANDS with comma delimited values

### DIFF
--- a/src/help.js
+++ b/src/help.js
@@ -119,7 +119,7 @@ const getHelpCommands = function getHelpCommands (robot) {
 }
 
 const hiddenCommandsPattern = function hiddenCommandsPattern () {
-  const hiddenCommands = process.env.HUBOT_HELP_HIDDEN_COMMANDS != null ? process.env.HUBOT_HELP_HIDDEN_COMMANDS.split(',') : undefined
+  const hiddenCommands = process.env.HUBOT_HELP_HIDDEN_COMMANDS != null ? process.env.HUBOT_HELP_HIDDEN_COMMANDS.split(',').map(c => c.trim()) : undefined
   if (hiddenCommands) {
     return new RegExp(`^hubot (?:${hiddenCommands != null ? hiddenCommands.join('|') : undefined}) - `)
   }

--- a/test/help_test.js
+++ b/test/help_test.js
@@ -52,13 +52,26 @@ describe('help', () => describe('getHelpCommands', () => {
     return this.robot.adapter.receive(new TextMessage(this.user, 'hubot help'))
   }))
 
-  context('when HUBOT_HELP_HIDDEN_COMMANDS is set', () => it('lists all commands but those in environment variable', function (done) {
+  context('when HUBOT_HELP_HIDDEN_COMMANDS is set with 1 command', () => it('lists all commands but one set in environment variable', function (done) {
     process.env.HUBOT_HELP_HIDDEN_COMMANDS = 'help'
     this.robot.adapter.on('send', function (envelope, strings) {
       const commands = strings[0].split('\n')
 
       expect(commands.length).to.eql(1)
       expect(commands[0]).to.match(/hubot help <query> - Displays all help commands that match <query>/)
+
+      return done()
+    })
+
+    return this.robot.adapter.receive(new TextMessage(this.user, 'hubot help'))
+  }))
+
+  context('when HUBOT_HELP_HIDDEN_COMMANDS is set with multiple commands', () => it('lists all commands but comma separated ones in environment variable', function (done) {
+    process.env.HUBOT_HELP_HIDDEN_COMMANDS = 'help, help <query>'
+    this.robot.adapter.on('send', function (envelope, strings) {
+      const commands = strings[0].split('\n').filter(command => command.trim().length > 0)
+
+      expect(commands.length).to.eql(0)
 
       return done()
     })


### PR DESCRIPTION
process.env.HUBOT_HELP_HIDDEN_COMMANDS = 'help, help <query>' wasn't working because the second `help <query>` had a space in front of it. This change fixes that situation.

#49 