### PR TITLE
fix: Replying to help in a private message.

### DIFF
--- a/src/help.js
+++ b/src/help.js
@@ -74,7 +74,7 @@ module.exports = (robot) => {
 
     if (process.env.HUBOT_HELP_REPLY_IN_PRIVATE && msg.message && msg.message.user && msg.message.user.name && msg.message.user.name !== msg.message.room) {
       msg.reply('I just replied to you in private.')
-      return msg.sendPrivate(emit)
+      return robot.send({ room: msg.message.user.id }, emit)
     } else {
       return msg.send(emit)
     }


### PR DESCRIPTION
Replying to help in a private message wasn't working anymore. The Hubot Response API no longer supports `sendPrivate` and the Slack adapter requires the room to be the users id.

Reference #47 .

PR #60 tries to address this, but discussion on it got stale. So I created a new PR to address this issue.