### PR TITLE
fix: Publish to latest on npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "hubot-help",
   "description": "A hubot script to show available hubot commands",
   "version": "0.0.0-development",
-  "publishConfig": {
-    "tag": "next"
-  },
   "author": "Josh Nichols <josh@technicalpickles.com>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Fixes not publishing to the `latest` tag on npmjs. #72 